### PR TITLE
crash fix for empty attendance data

### DIFF
--- a/zklib/zkattendance.js
+++ b/zklib/zkattendance.js
@@ -51,8 +51,9 @@ module.exports = class {
 
           reply = this.connectionType === ConnectionTypes.UDP ? reply : removeTcpHeader(reply);
 
-          if (reply && reply.length) {
-            total_bytes = reply.readUInt32LE(8) - 4;
+          var offset = 8;
+          if (reply && offset <= reply.length - 4) {
+            total_bytes = reply.readUInt32LE(offset) - 4;
             total_bytes += 2;
 
             if (total_bytes <= 0) {


### PR DESCRIPTION
Was crashing for empty attendance. Error log:

		buffer.js:977
			throw new RangeError('Index out of range');
			^
		RangeError: Index out of range
			at checkOffset (buffer.js:977:11)
			at Uint8Array.Buffer.readUInt32LE (buffer.js:1039:5)
			at Socket.handleOnData (P:\WebApp\ZKTecoDataCollector\node_modules\zklib\zklib\zkattendance.js:55:33)
			at emitTwo (events.js:131:20)
			at Socket.emit (events.js:214:7)
			at UDP.onMessage [as onmessage] (dgram.js:659:8)

Fix reference: https://nodejs.org/api/buffer.html#buffer_buf_readuint32le_offset